### PR TITLE
Disable specific ubsan checks for a handful of functions

### DIFF
--- a/include/rapidcheck/detail/BitStream.hpp
+++ b/include/rapidcheck/detail/BitStream.hpp
@@ -38,7 +38,10 @@ T BitStream<Source>::next(int /*nbits*/, std::true_type) {
 
 template <typename Source>
 template <typename T>
-T BitStream<Source>::next(int nbits, std::false_type) {
+T BitStream<Source>::next(int nbits, std::false_type) 
+  __attribute__((no_sanitize("implicit-signed-integer-truncation"))) 
+  __attribute__((no_sanitize("implicit-integer-sign-change"))) 
+{
   using SourceType = decltype(m_source.next());
 
   if (nbits == 0) {

--- a/include/rapidcheck/detail/BitStream.hpp
+++ b/include/rapidcheck/detail/BitStream.hpp
@@ -39,8 +39,10 @@ T BitStream<Source>::next(int /*nbits*/, std::true_type) {
 template <typename Source>
 template <typename T>
 T BitStream<Source>::next(int nbits, std::false_type) 
+#ifdef __clang__
   __attribute__((no_sanitize("implicit-signed-integer-truncation"))) 
   __attribute__((no_sanitize("implicit-integer-sign-change"))) 
+#endif
 {
   using SourceType = decltype(m_source.next());
 

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -96,7 +96,9 @@ inline uint64_t avalanche(uint64_t x) {
 /// and the rest set to 0.
 template <typename T>
 constexpr T bitMask(int nbits) 
+#ifdef __clang__
   __attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 {
   using UT = typename std::make_unsigned<T>::type;
   using UTP = typename std::common_type<UT, unsigned>::type;

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -95,7 +95,9 @@ inline uint64_t avalanche(uint64_t x) {
 /// Returns a bitmask of the given type with the lowest `nbits` bits set to 1
 /// and the rest set to 0.
 template <typename T>
-constexpr T bitMask(int nbits) {
+constexpr T bitMask(int nbits) 
+  __attribute__((no_sanitize("unsigned-shift-base")))
+{
   using UT = typename std::make_unsigned<T>::type;
   using UTP = typename std::common_type<UT, unsigned>::type;
   // There are two pieces of undefined behavior we're avoiding here,

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -1,8 +1,8 @@
 #include "rapidcheck/Random.h"
 
-#include <iostream>
 #include <cassert>
 #include <functional>
+#include <iostream>
 
 #include "rapidcheck/Show.h"
 
@@ -67,7 +67,9 @@ void Random::append(bool x) {
   m_bitsi++;
 }
 
-void Random::mash(Block &output) {
+void Random::mash(Block &output) 
+  __attribute__((no_sanitize("unsigned-shift-base")))
+{
   // Input
   uint64_t b0 = m_bits;
   uint64_t b1 = m_counter;

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -1,8 +1,8 @@
 #include "rapidcheck/Random.h"
 
+#include <iostream>
 #include <cassert>
 #include <functional>
-#include <iostream>
 
 #include "rapidcheck/Show.h"
 
@@ -68,7 +68,9 @@ void Random::append(bool x) {
 }
 
 void Random::mash(Block &output) 
+#ifdef __clang__
   __attribute__((no_sanitize("unsigned-shift-base")))
+#endif
 {
   // Input
   uint64_t b0 = m_bits;


### PR DESCRIPTION
Looking to make use of ubsan in other projects, but there are some complete non-issues which are being reported from rapidcheck when using higher levels of checks. Add some function attributes to disable instrumentation of these functions when compiling with clang