### PR TITLE
GCC 13.1.X fix

### DIFF
--- a/include/rapidcheck/detail/Results.hpp
+++ b/include/rapidcheck/detail/Results.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace rc {
 namespace detail {
 

--- a/include/rapidcheck/detail/Serialization.hpp
+++ b/include/rapidcheck/detail/Serialization.hpp
@@ -202,9 +202,8 @@ Iterator deserializeCompact(Iterator begin, Iterator end, T &output) {
 }
 
 template <typename InputIterator, typename OutputIterator>
-OutputIterator serializeCompact(InputIterator begin,
-                                InputIterator end,
-                                OutputIterator output) {
+OutputIterator
+serializeCompact(InputIterator begin, InputIterator end, OutputIterator output) {
   const std::uint64_t numElements = std::distance(begin, end);
   auto oit = serializeCompact(numElements, output);
   for (auto it = begin; it != end; it++) {

--- a/include/rapidcheck/detail/Serialization.hpp
+++ b/include/rapidcheck/detail/Serialization.hpp
@@ -1,5 +1,6 @@
 #include "Serialization.h"
 
+#include <cstdint>
 #include <limits>
 
 namespace rc {
@@ -201,8 +202,9 @@ Iterator deserializeCompact(Iterator begin, Iterator end, T &output) {
 }
 
 template <typename InputIterator, typename OutputIterator>
-OutputIterator
-serializeCompact(InputIterator begin, InputIterator end, OutputIterator output) {
+OutputIterator serializeCompact(InputIterator begin,
+                                InputIterator end,
+                                OutputIterator output) {
   const std::uint64_t numElements = std::distance(begin, end);
   auto oit = serializeCompact(numElements, output);
   for (auto it = begin; it != end; it++) {

--- a/include/rapidcheck/detail/Utility.h
+++ b/include/rapidcheck/detail/Utility.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <tuple>
 #include <limits>

--- a/src/detail/Base64.h
+++ b/src/detail/Base64.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
# Changes

Using GCC 13.1.1 compiler gives you a number of missing `cstdint` types errors. This PR fixes it.
